### PR TITLE
upgrade react-jsonschema-form to allow disabling html5 validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "react": "^16.2.0",
     "react-bootstrap": "^0.32.1",
     "react-dom": "^16.2.0",
-    "react-jsonschema-form": "^1.0.0",
+    "react-jsonschema-form": "^1.2.1",
     "react-redux": "^5.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",

--- a/src/components/AssetDetail.js
+++ b/src/components/AssetDetail.js
@@ -30,6 +30,7 @@ export default class AssetDetail extends React.Component {
                       formData={this.state.formData}
                       onChange={log("changed")}
                       liveValidate={true}
+                      noHtml5Validate={true}
                       onSubmit={this.props.submitAsset}
                       onError={log("errors")}/> )
 


### PR DESCRIPTION
upgrade react-jsonschema-form to allow disabling html5 validation thus  avoiding std html5 validation check on checkboxes